### PR TITLE
Fix data_manipulation bug

### DIFF
--- a/R/data_manipulation.R
+++ b/R/data_manipulation.R
@@ -38,8 +38,7 @@ data_manipulation <- function(data, use_censor = TRUE) {
   event_data <- event_data[, list(id, time_of_event)]
 
   sw_data <- data[event_data, on = "id"]
-
-  sw_data <- sw_data[, first := !duplicated(data[, id])]
+  sw_data <- sw_data[, first := !duplicated(id)]
   sw_data <- sw_data[, am_1 := shift(treatment, type = "lag"), by = "id"]
   sw_data[first == TRUE, cumA := 0]
   sw_data[first == TRUE, am_1 := 0]

--- a/tests/testthat/test-data_manipulation.R
+++ b/tests/testthat/test-data_manipulation.R
@@ -57,6 +57,7 @@ test_that("data_manipulation works as expected with observations before eligibil
     nrow = 255,
     ncol = 20
   )
+  expect_equal(min(result[id == 1, ]$period), 262)
 })
 
 test_that("data_manipulation works as expected with observations after outcome", {
@@ -73,4 +74,5 @@ test_that("data_manipulation works as expected with observations after outcome",
     nrow = 210,
     ncol = 20
   )
+  expect_equal(max(result[id == 1, ]$period), 350)
 })

--- a/tests/testthat/test-data_manipulation.R
+++ b/tests/testthat/test-data_manipulation.R
@@ -42,3 +42,35 @@ test_that("data_manipulation works as expected with censoring", {
   )
   expect_equal(length(unique(result$id)), 503L)
 })
+
+test_that("data_manipulation works as expected with observations before eligibilitiy", {
+  object <- as.data.table(trial_example)[id %in% 1:3]
+  object <- object[id == 1 & period == 261, eligible := 0]
+  expect_warning(
+    result <- data_manipulation(object, use_censor = TRUE),
+    "before trial eligibility"
+  )
+
+  expect_data_table(
+    result,
+    key = "id",
+    nrow = 255,
+    ncol = 20
+  )
+})
+
+test_that("data_manipulation works as expected with observations after outcome", {
+  object <- as.data.table(trial_example)[id %in% 1:3]
+  object <- object[id == 1 & period == 350, outcome := 1]
+  expect_warning(
+    result <- data_manipulation(object, use_censor = TRUE),
+    "after the outcome occured"
+  )
+
+  expect_data_table(
+    result,
+    key = "id",
+    nrow = 210,
+    ncol = 20
+  )
+})

--- a/tests/testthat/test-data_manipulation.R
+++ b/tests/testthat/test-data_manipulation.R
@@ -27,7 +27,7 @@ test_that("data_manipulation works as expected with censoring", {
   expect_data_table(
     result,
     key = "id",
-    nrow = 38734,
+    nrow = 38820,
     ncol = 20
   )
   expect_set_equal(


### PR DESCRIPTION
If data was not sorted by id and period, some observations may have been lost.