### PR TITLE
Fixing build issue related to new "na.print" argument in data.table

### DIFF
--- a/R/data_extension.R
+++ b/R/data_extension.R
@@ -51,7 +51,7 @@ data_extension <- function(data,
       N <- N + nrow(switch_data)
       for (p in unique(switch_data[["trial_period"]])) {
         file_p <- file.path(data_dir, paste0("trial_", p, ".csv"))
-        fwrite(switch_data[trial_period == p, ], file_p, append = TRUE)
+        fwrite(switch_data[trial_period == p, ], file = file_p, append = TRUE)
       }
     }
     files <- file.path(data_dir, paste0("trial_", first_period:last_period, ".csv"))
@@ -188,9 +188,9 @@ expand <- function(sw_data,
     switch_data[(switch_new == 0 & time_of_event == period_new & outcome_new == 1), case := 1]
   }
 
-  setnames(switch_data, c("case"), c("outcome"))
-  setnames(switch_data, c("init"), c("assigned_treatment"))
-  setnames(switch_data, c("treatment_new"), c("treatment"))
+  setnames(switch_data, old = c("case"), new = c("outcome"))
+  setnames(switch_data, old = c("init"), new = c("assigned_treatment"))
+  setnames(switch_data, old = c("treatment_new"), new = c("treatment"))
   switch_data <- switch_data[expand == 1]
   switch_data <- switch_data[, keeplist, with = FALSE]
 

--- a/R/generics.R
+++ b/R/generics.R
@@ -47,7 +47,7 @@ summary.TE_data_prep_sep <- function(object, ...) {
 
   n_files <- length(object$data)
   cat("Expanded data saved in ", n_files, " csv file", if (n_files > 1) "s" else "", ":\n", sep = "")
-  print(data.table(data = object$data), topn = 3, n = 5, col.names = "none", ...)
+  print(data.table(data = object$data), topn = 3, nrows = 5, col.names = "none", ...)
   cat("\n\n")
   NextMethod()
 }

--- a/R/predict.R
+++ b/R/predict.R
@@ -112,7 +112,7 @@ predict.TE_msm <- function(object,
           c("followup_time", col_names, "2.5%", "97.5%")
         )
       } else {
-        setNames(data.frame(predict_times, pred_matrix[, 1]), c("followup_time", col_names))
+        setNames(data.frame(predict_times, pred_matrix[, 1]), nm = c("followup_time", col_names))
       }
     }
   )

--- a/R/sampling.R
+++ b/R/sampling.R
@@ -103,7 +103,7 @@ sample_from_period <- function(period_data,
                                subset_expr,
                                sort = FALSE) {
   if (use_subset) period_data <- subset(period_data, eval(subset_expr))
-  if (isTRUE(sort)) setorderv(period_data, c("followup_time", "id"))
+  if (isTRUE(sort)) setorderv(period_data, cols = c("followup_time", "id"))
   followup_split <- split(period_data, by = "followup_time")
 
   all_samples <- lapply(p_control, function(p) {


### PR DESCRIPTION
Thanks Toby @tdhock for bringing this to my attention via [issue in data.table](https://github.com/Rdatatable/data.table/issues/6098).

Recently, a new argument was added to `print.data.table`, which affected re-building of vignettes, as outlined in the original issue. Credit to @MichaelChirico for the find; the issue was here:

https://github.com/Causal-LDA/TrialEmulation/blob/989f064dfcb68f37ebdf280b2c37f8ee845aae0d/R/generics.R#L50

With the new `na.print` argument, `n = 5` is no longer partially matched to `nrows`, so the change is trivial. I've also gone ahead and taken a quick look at other function calls that could avoid partial matching in its arguments, and changed those as well.